### PR TITLE
Corrected typo in index.jsx

### DIFF
--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -20,7 +20,7 @@ const SideBar = () => {
 const SideBarIcon = ({ icon, text = 'tooltip 💡' }) => (
   <div className="sidebar-icon group">
     {icon}
-    <span class="sidebar-tooltip group-hover:scale-100">
+    <span className="sidebar-tooltip group-hover:scale-100">
       {text}
     </span>
   </div>


### PR DESCRIPTION
In JSX we use ```className``` instead of ```class``` .