### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "autoprefixer": "^10.4.4",
     "postcss": "^8.4.12",
-    "tailwindcss": "^3.0.23",
+    "tailwindcss": "^3.0.23"
   }
 }


### PR DESCRIPTION
Simply an extra comma at line 37 of the packagelock.json